### PR TITLE
update scylla dependency to 0.4

### DIFF
--- a/metric-collector/Cargo.toml
+++ b/metric-collector/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 chrono = "0.4"
-scylla = "0.2.0"
+scylla = "0.4"
 tokio = { version = "1.1.0", features = ["full"] }
 futures = "0.3.6"
 uuid = { version = "0.8", features = ["serde", "v4", "v5"] }
@@ -14,3 +14,4 @@ num-bigint = "0.3"
 tracing = "0.1.25"
 tracing-subscriber = "0.2.16"
 rand = "0.7.0" 
+console-subscriber = "0"

--- a/metric-reader/Cargo.toml
+++ b/metric-reader/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 chrono = "0.4"
-scylla = "0.2.0"
+scylla = "0.4"
 tokio = { version = "1.1.0", features = ["full"] }
 futures = "0.3.6"
 uuid = { version = "0.8", features = ["serde", "v4", "v5"] }

--- a/uuid_finder/Cargo.toml
+++ b/uuid_finder/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 chrono = "0.4"
-scylla = "0.2.0"
+scylla = "0.4"
 tokio = { version = "1.1.0", features = ["full"] }
 futures = "0.3.6"
 uuid = { version = "0.8", features = ["serde", "v4", "v5"] }


### PR DESCRIPTION
0.4 has lots of fixes applied. Also, the patch version is no longer
specified, which is good practice - it will trigger automatic update
when a fix is released.